### PR TITLE
output_transform 

### DIFF
--- a/torchmd/run.py
+++ b/torchmd/run.py
@@ -195,7 +195,8 @@ def setup(args):
             embeddings = torch.tensor(args.external["embeddings"]).repeat(
                 args.replicas, 1
             )
-        external = externalmodule.External(args.external["file"], embeddings, device)
+        output_transform = args.external["output_transform"] if "output_transform" in args.external else None
+        external = externalmodule.External(args.external["file"], embeddings, device, output_transform)
 
     system = System(mol.numAtoms, args.replicas, precision, device)
     system.set_positions(mol.coords)

--- a/torchmd/run.py
+++ b/torchmd/run.py
@@ -180,7 +180,8 @@ def setup(args):
     if args.external is not None:
         externalmodule = importlib.import_module(args.external["module"])
         embeddings = torch.tensor(args.external["embeddings"]).repeat(args.replicas, 1)
-        external = externalmodule.External(args.external["file"], embeddings, device)
+        output_transform = args.external["output_transform"] if "output_transform" in args.external else None
+        external = externalmodule.External(args.external["file"], embeddings, device, output_transform)
 
     system = System(mol.numAtoms, args.replicas, precision, device)
     system.set_positions(mol.coords)

--- a/torchmd/run.py
+++ b/torchmd/run.py
@@ -10,13 +10,12 @@ from torchmd.wrapper import Wrapper
 import numpy as np
 from tqdm import tqdm
 import argparse
-import math
 import importlib
 from torchmd.integrator import maxwell_boltzmann
 from torchmd.utils import save_argparse, LogWriter, LoadFromFile
 from torchmd.minimizers import minimize_bfgs
 from npzMol import npzMolecule
-from utils import elements, converter_xyz_output
+from utils import converter_xyz_output
 
 FS2NS = 1e-6
 batch_comp = False

--- a/torchmd/utils.py
+++ b/torchmd/utils.py
@@ -78,7 +78,7 @@ def save_argparse(args, filename, exclude=None):
 def converter_xyz_output(input_file, output_file, z=None):
     from moleculekit.periodictable import periodictable_by_number
     # it gets the embedding data from the mol.z attribute
-    mol_elements = z
+    mol_elements = np.array(z)
     npy_file = np.load(input_file)
     Nsteps = npy_file.shape[2]
     Nats = npy_file.shape[0]


### PR DESCRIPTION
We can enhance the initialization of the external_module by adding the `output_transform` argument. In the torchmd-net.calculator, the default value of this argument is set to None, which means it returns the identity transformation. However, now you have the flexibility to specify the desired transformer to be applied through the external arguments in the YAML configuration file of torchmd. Keep in mind that torchmd operates using kcal/mol for energy and kcal/mol/A for forces as units of measure.
Change according to torchm-net PR [#167](https://github.com/torchmd/torchmd-net/pull/167) 