### PR TITLE
npy file for embedding

### DIFF
--- a/torchmd/run.py
+++ b/torchmd/run.py
@@ -189,9 +189,14 @@ def setup(args, batch_comp=False):
         if batch_comp:
             embeddings = torch.tensor(mol.embedding).repeat(args.replicas, 1)
         else:
-            embeddings = torch.tensor(args.external["embeddings"]).repeat(
-                args.replicas, 1
-            )
+            if isinstance(args.external["embeddings"], str):
+                embeddings = torch.tensor(
+                    np.load(args.external["embeddings"]).astype(int)
+                ).repeat(args.replicas, 1)
+            else:
+                embeddings = torch.tensor(args.external["embeddings"]).repeat(
+                    args.replicas, 1
+                )
         output_transform = (
             args.external["output_transform"]
             if "output_transform" in args.external


### PR DESCRIPTION
In this pull request, I propose the utilization of an npy file for loading the embedding rather than a list. This enhancement enables running the code by providing either the path to the embedding.npy file or a list of integer values (retro-compatible). This modification proves highly beneficial, especially when working with bigger molecules or protein sequences.