### PR TITLE
XYZwriter also for moleculekit object

### DIFF
--- a/torchmd/npzMol.py
+++ b/torchmd/npzMol.py
@@ -4,12 +4,12 @@ from moleculekit.periodictable import periodictable_by_number
 
 
 class npzMolecule:
-    """Class to load npz files in torchmd, essentially a wrapper around the npz file. Necessary information is extracted from the npz file
-    and stored in the class, such as the coordinates and the atomic numbers. The class also contains a dictionary to convert atomic numbers to
-    atomic symbols. Additional properties such as the box, the charges and the bonds are also stored in the class but are not necessary for the
-    simulation."""
-
     def __init__(self, file: str):
+    """Class to load npz files in torchmd, essentially a wrapper around the npz file. Necessary information is extracted from the npz file
+    and stored in the class, such as the coordinates and the atomic numbers. The class also contains a dictionary to get atom masses from 
+    atomic numbers. Additional properties such as the box, the charges and the bonds are also stored in the class but are not necessary for 
+    the simulation."""    
+    
         self.converter = {
             "1": 1.0080,
             "6": 12.011,

--- a/torchmd/run.py
+++ b/torchmd/run.py
@@ -15,7 +15,7 @@ from torchmd.integrator import maxwell_boltzmann
 from torchmd.utils import save_argparse, LogWriter, LoadFromFile
 from torchmd.minimizers import minimize_bfgs
 from npzMol import npzMolecule
-from utils import converter_xyz_output
+from utils import xyz_writer
 
 FS2NS = 1e-6
 batch_comp = False
@@ -277,7 +277,7 @@ def dynamics(args, mol, system, forces):
     for k in range(args.replicas):
         npy_name = os.path.join(args.log_dir, args.output + f"_{k}.npy")
         xyz_name = os.path.join(args.log_dir, args.output + f"_{k}.xyz")
-        converter_xyz_output(npy_name, xyz_name, mol.z)
+        xyz_writer(npy_name, xyz_name, mol.element)
 
 
 if __name__ == "__main__":

--- a/torchmd/utils.py
+++ b/torchmd/utils.py
@@ -75,10 +75,12 @@ def save_argparse(args, filename, exclude=None):
                 f.write(f"{k}={v}\n")
 
 
-def converter_xyz_output(input_file, output_file, z=None):
-    from moleculekit.periodictable import periodictable_by_number
-    # it gets the embedding data from the mol.z attribute
-    mol_elements = np.array(z)
+def xyz_writer(input_file, output_file, mol_elements):
+    """Writes xyz file from npy file, one xyz trajectory per replica.
+    Args:
+    input_file: path to npy file
+    output_file: path to xyz file
+    mol_elements: list of elements in the molecule"""
     npy_file = np.load(input_file)
     Nsteps = npy_file.shape[2]
     Nats = npy_file.shape[0]
@@ -89,7 +91,7 @@ def converter_xyz_output(input_file, output_file, z=None):
             f.write("\n\n")
             for j in range(Nats):
                 if "forces" not in input_file:
-                    f.write(periodictable_by_number[mol_elements[j]].symbol)
+                    f.write(mol_elements[j])
                     f.write(" ")
                 for k in range(3):
                     f.write(str(npy_file[j, k, i]))


### PR DESCRIPTION
I notices that the moleculekit object give an error during the xyz_writing.  Here I propose an update version that it's able to work with both npzmol and moleculekit object. 
Key points:
- [x] `element` attribute to the npzMolecule object using moleculekit.periodictable so we have the same attribute as in moleculekit object;
- [x] new name for the `xyz_writer` function with relative documentation;
- [x] now the xyz_writer function use directly the `mol.element` to write the element symbol in the xyz file;

The error which I'm referring to fix: 
![image](https://github.com/torchmd/torchmd/assets/101815262/9e8d4f24-85d8-4a02-8eb8-db5946ad38bc) 