### PR TITLE
Reshape positions in minimizer to have the required 1D array for scipy

### DIFF
--- a/torchmd/minimizers.py
+++ b/torchmd/minimizers.py
@@ -29,7 +29,7 @@ def minimize_bfgs(system, forces, fmax=0.5, steps=1000):
         return Epot, grad.reshape(-1)
 
     print("{0:4s} {1:9s}       {2:9s}".format("Iter", " Epot", " fmax"))
-    x0 = system.pos.detach().cpu().numpy()[0].astype(np.float64).reshape(-1)
+    x0 = system.pos.detach().cpu().numpy()[0].astype(np.float64).flatten()
 
     res = minimize(
         evalfunc,

--- a/torchmd/minimizers.py
+++ b/torchmd/minimizers.py
@@ -29,7 +29,7 @@ def minimize_bfgs(system, forces, fmax=0.5, steps=1000):
         return Epot, grad.reshape(-1)
 
     print("{0:4s} {1:9s}       {2:9s}".format("Iter", " Epot", " fmax"))
-    x0 = system.pos.detach().cpu().numpy()[0].astype(np.float64)
+    x0 = system.pos.detach().cpu().numpy()[0].astype(np.float64).reshape(-1)
 
     res = minimize(
         evalfunc,


### PR DESCRIPTION
Latest versions of scipy will raise if the initial guess is not a 1D array. This PR flattens the array before passing it to minimize.